### PR TITLE
Switch universal agent endpoints to Core DNS

### DIFF
--- a/genesis/images/genesis_base/etc/genesis_universal_agent/genesis_universal_agent.conf
+++ b/genesis/images/genesis_base/etc/genesis_universal_agent/genesis_universal_agent.conf
@@ -3,6 +3,6 @@ verbose = True
 debug = True
 
 [universal_agent]
-orch_endpoint = http://10.20.0.2:11011
-status_endpoint = http://10.20.0.2:11012
+orch_endpoint = http://core.local.genesis-core.tech:11011
+status_endpoint = http://core.local.genesis-core.tech:11012
 caps_drivers = RenderAgentDriver


### PR DESCRIPTION
Core DNS has been released so get rid of hardcoded IP addresses and use pretty domain name of Genesis Core.

```
ubuntu@ubuntu:~$ curl http://core.local.genesis-core.tech:11011/v1/agents/ | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   747  100   747    0     0   199k      0 --:--:-- --:--:-- --:--:--  243k
[
  {
    "uuid": "f82bc553-69e3-4991-9ccc-8ee0a3a64725",
    "name": "Universal Agent f82bc553",
    "description": "",
    "created_at": "2025-07-07T15:33:12.729633Z",
    "updated_at": "2025-07-07T15:33:12.729641Z",
    "capabilities": {
      "capabilities": [
        "em_core_compute_nodes",
        "em_core_config_configs",
        "em_core_secret_passwords",
        "password"
      ]
    },
    "facts": {
      "facts": []
    },
    "node": "f82bc553-69e3-4991-9ccc-8ee0a3a64725",
    "status": "ACTIVE"
  },
  {
    "uuid": "ea3e4b8b-edec-46d8-b9e6-a1e05afd20f4",
    "name": "Universal Agent ea3e4b8b",
    "description": "",
    "created_at": "2025-07-07T15:49:21.688174Z",
    "updated_at": "2025-07-07T15:49:21.688180Z",
    "capabilities": {
      "capabilities": [
        "render"
      ]
    },
    "facts": {
      "facts": []
    },
    "node": "ea3e4b8b-edec-46d8-b9e6-a1e05afd20f4",
    "status": "ACTIVE"
  }
]
ubuntu@ubuntu:~$ 
```