### PR TITLE
Support new devtools format for only image builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ help:
 	@echo "build            - build base image"
 
 build:
-	exordos build -i $(SSH_KEY) -f .
+	exordos build -i $(SSH_KEY) -f --only-images

--- a/exordos/images/exordos_base/etc/apt/sources.list
+++ b/exordos/images/exordos_base/etc/apt/sources.list
@@ -2,9 +2,9 @@
 # file, which uses the deb822 format. Use deb822-formatted .sources files
 # to manage package sources in the /etc/apt/sources.list.d/ directory.
 # See the sources.list(5) manual page for details.
-deb http://mirror.yandex.ru/ubuntu noble-updates universe main multiverse
-# deb-src http://mirror.yandex.ru/ubuntu noble-updates universe main multiverse
-deb http://mirror.yandex.ru/ubuntu noble main universe multiverse
-# deb-src http://mirror.yandex.ru/ubuntu noble main universe multiverse
-deb http://mirror.yandex.ru/ubuntu noble-security universe main multiverse
-# deb-src http://mirror.yandex.ru/ubuntu noble-security main universe multiverse
+deb http://mirror.yandex.ru/ubuntu release-updates universe main multiverse
+# deb-src http://mirror.yandex.ru/ubuntu release-updates universe main multiverse
+deb http://mirror.yandex.ru/ubuntu release main universe multiverse
+# deb-src http://mirror.yandex.ru/ubuntu release main universe multiverse
+deb http://mirror.yandex.ru/ubuntu release-security universe main multiverse
+# deb-src http://mirror.yandex.ru/ubuntu release-security main universe multiverse

--- a/exordos/images/exordos_base/install.sh
+++ b/exordos/images/exordos_base/install.sh
@@ -39,11 +39,12 @@ if [ -f /etc/apt/sources.list ]; then
     sudo mv /etc/apt/sources.list /etc/apt/sources.list.bak
 fi
 sudo cp "$IMG_ARTS_PATH/etc/apt/sources.list" /etc/apt/sources.list
+sudo sed -i "s/release/$(lsb_release -cs)/g" /etc/apt/sources.list
 
 # Install packages
 sudo apt update
 sudo apt dist-upgrade -y
-sudo apt install -y build-essential python3.12-dev python3.12-venv \
+sudo apt install -y build-essential python3-dev python3-venv \
     cloud-guest-utils irqbalance qemu-guest-agent libev-dev rsync parted j2cli
 
 export UV_INSTALL_DIR="/usr/local/bin"


### PR DESCRIPTION
- Added support of the new devtools format to build only images.
- Fixes to be able to switch to Ubuntu 26.04