### PR TITLE
build: disable Alloy installation and reduce disk size

### DIFF
--- a/exordos/exordos.yaml
+++ b/exordos/exordos.yaml
@@ -32,4 +32,4 @@ build:
 
         # Override image build parameters, for instance Packer parameters
         override:
-          disk_size: "6G"
+          disk_size: "4500M"

--- a/exordos/images/exordos_base/install.sh
+++ b/exordos/images/exordos_base/install.sh
@@ -89,11 +89,12 @@ sudo cp -a "$IMG_ARTS_PATH/lib/." "/usr/local/lib/exordos/"
 # Enable exordos core services
 sudo systemctl enable exordos-bootstrap exordos-root-autoresize exordos-universal-agent
 
+# Commented out because we don't need Alloy for now and we are going to change monitoring solution
 # Install Alloy
-wget -q https://repo.exordos.com/alloy/alloy-${ALLOY_VERSION}-1.amd64.deb
-#wget -q https://github.com/grafana/alloy/releases/download/v${ALLOY_VERSION}/alloy-${ALLOY_VERSION}-1.amd64.deb
-sudo dpkg -i alloy-${ALLOY_VERSION}-1.amd64.deb
-rm -f alloy-${ALLOY_VERSION}-1.amd64.deb
+# wget -q https://repo.exordos.com/alloy/alloy-${ALLOY_VERSION}-1.amd64.deb
+# wget -q https://github.com/grafana/alloy/releases/download/v${ALLOY_VERSION}/alloy-${ALLOY_VERSION}-1.amd64.deb
+# sudo dpkg -i alloy-${ALLOY_VERSION}-1.amd64.deb
+# rm -f alloy-${ALLOY_VERSION}-1.amd64.deb
 
 # Set default password
 cat > /tmp/__passwd <<EOF
@@ -114,7 +115,7 @@ if [ -n "$LATEST_KERNEL_PKG" ]; then
     fi
 fi
 
-sudo apt autopurge -y snapd libllvm19
+sudo apt autopurge -y snapd libllvm19 python3-botocore python-babel-localedata python3-twisted
 sudo rm -fr /opt/eci_base
 sudo apt-get clean
 sudo rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- Comment out Alloy installation steps (monitoring solution to be revised)
- Add python3-botocore, python-babel-localedata, python3-twisted to autopurge to remove cloud-init dependencies
- Reduce disk_size from 6G to 4500M